### PR TITLE
feat: add Anticapture governance link to proposal notifications

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -51,7 +51,7 @@ export default {
       const author = ensName || truncateAddress(proposer);
       const link = `https://www.tally.xyz/gov/ens/proposal/${id}`;
 
-      const messageParts = [`Proposer: ${author}`, `Vote on [Tally](${link}) or [Agora](https://agora.ensdao.org/proposals/${id})`];
+      const messageParts = [`Proposer: ${author}`, `Vote on [Anticapture](https://app.anticapture.com/ens/governance/proposal/${id}), [Tally](${link}), or [Agora](https://agora.ensdao.org/proposals/${id})`];
 
       if (title) {
         // Push the title to the beginning of the message with an extra line break

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -51,7 +51,7 @@ export default {
       const author = ensName || truncateAddress(proposer);
       const link = `https://www.tally.xyz/gov/ens/proposal/${id}`;
 
-      const messageParts = [`Proposer: ${author}`, `Vote on [Anticapture](https://app.anticapture.com/ens/governance/proposal/${id}), [Tally](${link}), or [Agora](https://agora.ensdao.org/proposals/${id})`];
+      const messageParts = [`Proposer: ${author}`, `Vote on [Tally](${link}), [Agora](https://agora.ensdao.org/proposals/${id}) or [Anticapture](https://app.anticapture.com/ens/governance/proposal/${id})`];
 
       if (title) {
         // Push the title to the beginning of the message with an extra line break


### PR DESCRIPTION
Adds [Anticapture](https://app.anticapture.com) as a voting option in executable proposal notification messages, alongside Tally and Agora.

**Before:**
> Vote on [Tally](...) or [Agora](...)

**After:**
> Vote on [Anticapture](...), [Tally](...), or [Agora](...)